### PR TITLE
Sex maximum width for investigatory report image on petaluma poultry case page.

### DIFF
--- a/pages/petalumapoultry.tsx
+++ b/pages/petalumapoultry.tsx
@@ -31,7 +31,10 @@ const Reichardt: NextPage = () => {
       <a href="/cases/petalumapoultry/Petaluma Poultry Investigatory Report 2023.pdf"
         target="_blank">
         <div style={{
-          position: "relative"
+          position: "relative",
+          maxWidth: "1440px",
+          marginLeft: "auto",
+          marginRight: "auto"
         }}>
           <img src="/img/investigatory-report-fading-screenshot.jpg"
             alt="Investigatory report screenshot"


### PR DESCRIPTION
Before this change, the image would resize to the screen width, and the text in the image could become too large compared to other text on the page. An alternative to this change would have been to use an image with no text and overlay it with text in HTML that would remain proportional to other text.